### PR TITLE
Cilium Training Workshop by Solo.io

### DIFF
--- a/training/cilium-workshop-by-soloio/README.md
+++ b/training/cilium-workshop-by-soloio/README.md
@@ -1,0 +1,33 @@
+# Cilium training - Cilium and Gloo Mesh Workshop by Solo.io
+
+## Training Workshop Description:
+Cilium is an open source software for providing, securing and observing network connectivity between container workloads - cloud native, and fueled by the revolutionary Kernel technology eBPF.
+
+In this workshop, we will review the following:
+
+- Deployment of Cilium (including hubble) on a KinD Kubernetes cluster
+- Deployment of the bookinfo application
+- Looking at the service to service communication using the Hubble UI and then looking at the gRPC endpoint which provides the data used by the UI to build the graph
+- Leveraging network policies to secure service to service communications 
+
+
+This workshop also includes a certification option. This “Fundamentals for Cilium” credential, offered by Solo.io with Credly, certifies that you possess the essential skills to deploy the Cilium CNI on a test Kubernetes cluster, gather metrics and enforce network policies. At the completion of the workshop, you will be able to take an assessment and a score 80% or higher earns the certification.
+
+
+Solo.io has a number of workshops that are delivered on a weekly basis. 
+
+All workshops are here: https://www.solo.io/events/upcoming/#workshops
+
+These are the following workshops we deliver:
+* Envoy Basics
+* Istio, Getting Started
+* Istio for Production
+* Istio, Day 2 Operationalization
+* Introduction to Cilium
+* Gloo Mesh
+
+Our training class/workshop uses open-source Cilium.
+
+Please let us know when you would like to review and we can send you an invite to take the workshop.
+
+Please visit the landing Page for our training workshop: https://www.solo.io/solo-academy/workshops-cilium/


### PR DESCRIPTION
I have added a README.md to help with understanding what Solo.io's Cilium training workshop offers.
I would like to add this to the Cilium Website under the Training section, and have Solo.io listed as a training partner.

Signed-off-by: Marino Wijay <45947861+distributethe6ix@users.noreply.github.com>